### PR TITLE
BAH-2849 | Added  tags to the workflow

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -2,6 +2,8 @@ name: Build and Publish bahmni-metabase Image
 on:
   push:
     branches: main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   


### PR DESCRIPTION
While pushing a tag1.0.0 actions were not getting triggered though the tag is being created. Inorder to address this added tags under on push in workflow.