### PR TITLE
[Rahul] | BAH-3005 | Add. Timezone Global Value For Helm Charts

### DIFF
--- a/package/helm/templates/configMap.yaml
+++ b/package/helm/templates/configMap.yaml
@@ -8,3 +8,4 @@ data:
   MB_DB_PORT: "{{ .Values.config.MB_DB_PORT }}"
   OPENMRS_DB_NAME: "{{ .Values.config.OPENMRS_DB_NAME }}"
   MART_DB_NAME: "{{ .Values.config.MART_DB_NAME }}"
+  TZ: "{{ .Values.global.TZ }}"

--- a/package/helm/values.yaml
+++ b/package/helm/values.yaml
@@ -5,6 +5,7 @@ global:
   nodeSelector: {}
   affinity: {}
   tolerations: {}
+  TZ: "UTC"
 
 metadata:
   labels:


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to the helm charts to configure the timezone for the 
bahmni-metabase container.